### PR TITLE
fix: Server returns 400 Bad Request

### DIFF
--- a/wimse/server/server.go
+++ b/wimse/server/server.go
@@ -128,7 +128,7 @@ func (s *Server) getHttp() *http.Server {
 			digest, err := httpsign.GenerateContentDigestHeader(&resp.Body, []string{httpsign.DigestSha256})
 			if err != nil {
 				log.Printf("Unable to generate content digest: %v\n", err)
-				wimseError(w)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
 				return
 			}
 			resp.Header.Set("content-digest", digest)
@@ -148,13 +148,13 @@ func (s *Server) getHttp() *http.Server {
 
 		if err != nil {
 			log.Printf("Unable to create signer: %v\n", err)
-			wimseError(w)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		sigInput, sig, err := httpsign.SignResponse("wimse", *signer, resp, r)
 		if err != nil {
 			log.Printf("Unable to sign response: %v\n", err)
-			wimseError(w)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 

--- a/wimse/server/server.go
+++ b/wimse/server/server.go
@@ -25,6 +25,10 @@ import (
 	"github.com/yaronf/httpsign"
 )
 
+func returnWIMSEError(w http.ResponseWriter) {
+	http.Error(w, "Bad request", http.StatusBadRequest)
+}
+
 type Server struct {
 	// internal HTTP server
 	http *http.Server
@@ -69,7 +73,7 @@ func (s *Server) getHttp() *http.Server {
 		jwt, err := jose.ParseSigned(r.Header.Get("workload-identity-token"), []jose.SignatureAlgorithm{jose.ES256})
 		if err != nil {
 			log.Printf("Invalid token: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 
@@ -81,7 +85,7 @@ func (s *Server) getHttp() *http.Server {
 		}
 		if err := json.Unmarshal(jwt.UnsafePayloadWithoutVerification(), &payload); err != nil {
 			log.Printf("Invalid payload: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 
@@ -91,7 +95,7 @@ func (s *Server) getHttp() *http.Server {
 		pubInterface, err := x509.ParsePKIXPublicKey(keyBytes)
 		if err != nil {
 			log.Printf("failed to parse public key: %v", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 		clientEcdsa := pubInterface.(*ecdsa.PublicKey)
@@ -99,21 +103,21 @@ func (s *Server) getHttp() *http.Server {
 		verifier, err := httpsign.NewP256Verifier(*clientEcdsa, httpsign.NewVerifyConfig().SetKeyID("wimse"), httpsign.Headers("@request-target", "Workload-Identity-Token"))
 		if err != nil {
 			log.Printf("Unable to create verifier: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 
 		err = httpsign.VerifyRequest("wimse", *verifier, r)
 		if err != nil {
 			log.Printf("Invalid signature: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 
 		svid, err := s.GetWITSVID()
 		if err != nil {
 			log.Printf("Unable to get WIT SVID: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 
@@ -133,7 +137,7 @@ func (s *Server) getHttp() *http.Server {
 			digest, err := httpsign.GenerateContentDigestHeader(&resp.Body, []string{httpsign.DigestSha256})
 			if err != nil {
 				log.Printf("Unable to generate content digest: %v\n", err)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				returnWIMSEError(w)
 				return
 			}
 			resp.Header.Set("content-digest", digest)
@@ -153,13 +157,13 @@ func (s *Server) getHttp() *http.Server {
 
 		if err != nil {
 			log.Printf("Unable to create signer: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 		sigInput, sig, err := httpsign.SignResponse("wimse", *signer, resp, r)
 		if err != nil {
 			log.Printf("Unable to sign response: %v\n", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			returnWIMSEError(w)
 			return
 		}
 

--- a/wimse/server/server.go
+++ b/wimse/server/server.go
@@ -25,7 +25,7 @@ import (
 	"github.com/yaronf/httpsign"
 )
 
-func returnWIMSEError(w http.ResponseWriter) {
+func wimseError(w http.ResponseWriter) {
 	http.Error(w, "Bad request", http.StatusBadRequest)
 }
 
@@ -73,7 +73,7 @@ func (s *Server) getHttp() *http.Server {
 		jwt, err := jose.ParseSigned(r.Header.Get("workload-identity-token"), []jose.SignatureAlgorithm{jose.ES256})
 		if err != nil {
 			log.Printf("Invalid token: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 
@@ -85,7 +85,7 @@ func (s *Server) getHttp() *http.Server {
 		}
 		if err := json.Unmarshal(jwt.UnsafePayloadWithoutVerification(), &payload); err != nil {
 			log.Printf("Invalid payload: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 
@@ -95,7 +95,7 @@ func (s *Server) getHttp() *http.Server {
 		pubInterface, err := x509.ParsePKIXPublicKey(keyBytes)
 		if err != nil {
 			log.Printf("failed to parse public key: %v", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 		clientEcdsa := pubInterface.(*ecdsa.PublicKey)
@@ -103,21 +103,21 @@ func (s *Server) getHttp() *http.Server {
 		verifier, err := httpsign.NewP256Verifier(*clientEcdsa, httpsign.NewVerifyConfig().SetKeyID("wimse"), httpsign.Headers("@request-target", "Workload-Identity-Token"))
 		if err != nil {
 			log.Printf("Unable to create verifier: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 
 		err = httpsign.VerifyRequest("wimse", *verifier, r)
 		if err != nil {
 			log.Printf("Invalid signature: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 
 		svid, err := s.GetWITSVID()
 		if err != nil {
 			log.Printf("Unable to get WIT SVID: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 
@@ -137,7 +137,7 @@ func (s *Server) getHttp() *http.Server {
 			digest, err := httpsign.GenerateContentDigestHeader(&resp.Body, []string{httpsign.DigestSha256})
 			if err != nil {
 				log.Printf("Unable to generate content digest: %v\n", err)
-				returnWIMSEError(w)
+				wimseError(w)
 				return
 			}
 			resp.Header.Set("content-digest", digest)
@@ -157,13 +157,13 @@ func (s *Server) getHttp() *http.Server {
 
 		if err != nil {
 			log.Printf("Unable to create signer: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 		sigInput, sig, err := httpsign.SignResponse("wimse", *signer, resp, r)
 		if err != nil {
 			log.Printf("Unable to sign response: %v\n", err)
-			returnWIMSEError(w)
+			wimseError(w)
 			return
 		}
 


### PR DESCRIPTION
Per the draft spec https://www.ietf.org/archive/id/draft-ietf-wimse-http-signature-00.html#section-3.1

> An HTTP status code such as 400 (Bad Request) is appropriate. The response could include more details as per [[RFC9457](https://www.ietf.org/archive/id/draft-ietf-wimse-http-signature-00.html#RFC9457)], such as an indicator that the wrong key material or algorithm was used. The use of HTTP status code 401 is NOT RECOMMENDED for this purpose because it requires a WWW-Authenticate with acceptable http auth mechanisms in the error response and an associated Authorization header in the subsequent request. The use of these headers for the WIT is not compatible with this specification.

This PR replaces each instance where `401 Unauthorized` is return with a `400 Bad Request`


e.g. Running a call without the WIT
```
💤 wimse-s2s-httpsig-poc/ curl localhost:8080 -v                                                  (jsnctl/return-400)
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Mon, 10 Nov 2025 19:52:53 GMT
< Content-Length: 12
```