### PR TITLE
fix: Fixes expected JWK format, fixes logline typo, fixes README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sequenceDiagram
 
 To run the demo you need to run a `cofide/minispire` server:
 ```
-go run github.com/cofide/minispire/cmd@v0.2.1
+go run github.com/cofide/minispire/cmd@v0.2.2
 ```
 
 Then in another terminal run the server:

--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ WIT header and payload:
   "cnf": {
     "jwk": {
       "alg": "ES256",
-      "k": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu5lTCtfYxCwavDz5sGbaUEWjAUjeKDJFt93ziBKI2DHskPn3Fjq7IZS-S9A-l1IPzqkladSW-wYkpX1L6a9kvg",
-      "kty": "oct",
-      "use": "sig"
+      "crv": "P-256",
+      "kty": "EC",
+      "use": "sig",
+      "x": "XY5nlJAn3M6UVJk-kCUQj9EAGHS2v9rJDXbQ_WqvjkQ",
+      "y": "v-gMoFmV65_HDmtim9q0rGkPDvk-eGSPdqLsFzhukMc"
     }
   },
   "exp": 1761818361,

--- a/wimse/client/client.go
+++ b/wimse/client/client.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -205,13 +203,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("invalid payload: %w", err)
 	}
 
-	keyBytes := payload.Cnf.Jwk.Key.([]byte)
-	pubInterface, err := x509.ParsePKIXPublicKey(keyBytes)
-	if err != nil {
-		log.Printf("failed to parse public key: %v", err)
-		return nil, fmt.Errorf("unable to parse key: %w", err)
-	}
-	clientEcdsa := pubInterface.(*ecdsa.PublicKey)
+	clientEcdsa := payload.Cnf.Jwk.Key.(*ecdsa.PublicKey)
 
 	verifier, err := httpsign.NewP256Verifier(*clientEcdsa, httpsign.NewVerifyConfig().SetKeyID("wimse"), httpsign.Headers())
 	if err != nil {

--- a/wimse/server/server.go
+++ b/wimse/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -86,15 +85,7 @@ func (s *Server) getHttp() *http.Server {
 		}
 
 		slog.Info("wit", "wit", r.Header.Get("workload-identity-token"))
-
-		keyBytes := payload.Cnf.Jwk.Key.([]byte)
-		pubInterface, err := x509.ParsePKIXPublicKey(keyBytes)
-		if err != nil {
-			log.Printf("failed to parse public key: %v", err)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		clientEcdsa := pubInterface.(*ecdsa.PublicKey)
+		clientEcdsa := payload.Cnf.Jwk.Key.(*ecdsa.PublicKey)
 
 		verifier, err := httpsign.NewP256Verifier(*clientEcdsa, httpsign.NewVerifyConfig().SetKeyID("wimse"), httpsign.Headers("@request-target", "Workload-Identity-Token"))
 		if err != nil {

--- a/wimse/shared/wit.go
+++ b/wimse/shared/wit.go
@@ -47,7 +47,7 @@ func parseWITSVIDKey(encoded string) (*ecdsa.PrivateKey, error) {
 
 	parsedKey, err := x509.ParsePKCS8PrivateKey(keyBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %v", err)
+		return nil, fmt.Errorf("failed to parse private key: %v", err)
 	}
 
 	return parsedKey.(*ecdsa.PrivateKey), nil


### PR DESCRIPTION
* Changes to make use of `minispire` fix https://github.com/cofide/minispire/pull/14
* Ensures asymmetric key is used in `cnf`, fixes various parts accordingly
* NOTE: Requires a release of `minispire` to `v0.2.2`